### PR TITLE
Add async test examples

### DIFF
--- a/Assets/APIExamples/Tests/Editor/NUnit.meta
+++ b/Assets/APIExamples/Tests/Editor/NUnit.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5d0c0095342c40029ba296efd2fe432d
+timeCreated: 1666982173

--- a/Assets/APIExamples/Tests/Editor/NUnit/AsyncTestsExample.cs
+++ b/Assets/APIExamples/Tests/Editor/NUnit/AsyncTestsExample.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) 2022 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace APIExamples.Editor.NUnit
+{
+    /// <summary>
+    /// 非同期テストの実装例（Edit Modeテスト）
+    /// Async tests example (in Edit Mode tests)
+    /// </summary>
+    /// <remarks>
+    /// Required: Unity Test Framework v1.3 or later
+    /// </remarks>
+    public class AsyncTestsExample
+    {
+        [Test]
+        [Description("Can await Task")]
+        public async Task 非同期テストの例_Taskをawaitできる()
+        {
+            await Foo(1);
+            var actual = await Bar(2);
+            Assert.That(actual, Is.EqualTo(3));
+        }
+
+        private static async Task Foo(int id)
+        {
+            Debug.Log($"Start Foo({id})");
+            await Task.Delay(200);
+            Debug.Log($"Exit Foo({id})");
+        }
+
+        private static async Task<int> Bar(int id)
+        {
+            Debug.Log($"Start Bar({id})");
+            await Task.Delay(200);
+            Debug.Log($"Exit Bar({id})");
+            return id + 1;
+        }
+
+        [Test]
+        [Description("Can await UniTask")]
+        public async Task 非同期テストの例_UniTaskをawaitできる()
+        {
+            await UniTaskFoo(1);
+            var actual = await UniTaskBar(2);
+            Assert.That(actual, Is.EqualTo(3));
+        }
+
+        private static async UniTask UniTaskFoo(int id)
+        {
+            Debug.Log($"Start UniTaskFoo({id})");
+            await UniTask.Delay(200);
+            Debug.Log($"Exit UniTaskFoo({id})");
+        }
+
+        private static async UniTask<int> UniTaskBar(int id)
+        {
+            Debug.Log($"Start UniTaskBar({id})");
+            await UniTask.Delay(200);
+            Debug.Log($"Exit UniTaskBar({id})");
+            return id + 1;
+        }
+
+        [Test]
+        [Description("Can await Coroutine")]
+        [Explicit("Edit Modeテストではフリーズするため実行対象から除外/ Freeze in the Edit Mode tests")]
+        public async Task 非同期テストの例_コルーチンをawaitできる()
+        {
+            var actual = 0;
+            await FooMonoBehaviour.BarCoroutine(i =>
+            {
+                actual = i;
+            });
+
+            Assert.That(actual, Is.EqualTo(1));
+        }
+
+        // テスト対象コルーチンを含むMonoBehaviour
+        private class FooMonoBehaviour : MonoBehaviour
+        {
+            public static IEnumerator BarCoroutine(Action<int> onSuccess)
+            {
+                yield return null;
+                onSuccess(1);
+            }
+        }
+    }
+}

--- a/Assets/APIExamples/Tests/Editor/NUnit/AsyncTestsExample.cs.meta
+++ b/Assets/APIExamples/Tests/Editor/NUnit/AsyncTestsExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8c1a771bddb4d5d9bf1bb41fe34c844
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/APIExamples/Tests/Runtime/NUnit/AsyncSetupAttributeExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/AsyncSetupAttributeExample.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) 2022 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace APIExamples.NUnit
+{
+    /// <summary>
+    /// 非同期の<see cref="SetUpAttribute"/>, <see cref="TearDownAttribute"/>の例
+    /// Async SetUp and TearDown example
+    /// </summary>
+    /// <remarks>
+    /// Required: Unity Test Framework v1.3 or later
+    /// <see cref="OneTimeSetUpAttribute"/>, <see cref="OneTimeTearDownAttribute"/>はasyncサポートされていない
+    /// </remarks>
+    [UnityPlatform(exclude = new[] { RuntimePlatform.WebGLPlayer })]
+    public class AsyncSetupAttributeExample
+    {
+        /// <summary>
+        /// 各テストメソッドの前に実行されます
+        /// </summary>
+        [SetUp]
+        public async Task SetUp()
+        {
+            Debug.Log($"SetUp, {Time.time}");
+            await Task.Delay(200);
+        }
+
+        /// <summary>
+        /// 各テストメソッドの前に実行されます
+        /// </summary>
+        [TearDown]
+        public async Task TearDown()
+        {
+            Debug.Log($"TearDown, {Time.time}");
+            await Task.Delay(200);
+        }
+
+        [Test]
+        public void TestMethod()
+        {
+            Debug.Log($"TestMethod, {Time.time}");
+        }
+
+        [Test]
+        public void TestMethod2()
+        {
+            Debug.Log($"TestMethod2, {Time.time}");
+        }
+    }
+}

--- a/Assets/APIExamples/Tests/Runtime/NUnit/AsyncSetupAttributeExample.cs.meta
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/AsyncSetupAttributeExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71e53e0e73184154849df6540813592e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/APIExamples/Tests/Runtime/NUnit/AsyncTestsExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/AsyncTestsExample.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) 2022 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace APIExamples.NUnit
+{
+    /// <summary>
+    /// 非同期テストの実装例
+    /// Async tests example
+    /// </summary>
+    /// <remarks>
+    /// Required: Unity Test Framework v1.3 or later
+    /// </remarks>
+    [UnityPlatform(exclude = new[] { RuntimePlatform.WebGLPlayer })]
+    public class AsyncTestsExample
+    {
+        [Test]
+        [Description("Can await Task")]
+        public async Task 非同期テストの例_Taskをawaitできる()
+        {
+            await Foo(1);
+            var actual = await Bar(2);
+            Assert.That(actual, Is.EqualTo(3));
+        }
+
+        private static async Task Foo(int id)
+        {
+            Debug.Log($"Start Foo({id})");
+            await Task.Delay(200);
+            Debug.Log($"Exit Foo({id})");
+        }
+
+        private static async Task<int> Bar(int id)
+        {
+            Debug.Log($"Start Bar({id})");
+            await Task.Delay(200);
+            Debug.Log($"Exit Bar({id})");
+            return id + 1;
+        }
+
+        [Test]
+        [Description("Can await UniTask")]
+        public async Task 非同期テストの例_UniTaskをawaitできる()
+        {
+            await UniTaskFoo(1);
+            var actual = await UniTaskBar(2);
+            Assert.That(actual, Is.EqualTo(3));
+        }
+
+        private static async UniTask UniTaskFoo(int id)
+        {
+            Debug.Log($"Start UniTaskFoo({id})");
+            await UniTask.Delay(200);
+            Debug.Log($"Exit UniTaskFoo({id})");
+        }
+
+        private static async UniTask<int> UniTaskBar(int id)
+        {
+            Debug.Log($"Start UniTaskBar({id})");
+            await UniTask.Delay(200);
+            Debug.Log($"Exit UniTaskBar({id})");
+            return id + 1;
+        }
+
+        [Test]
+        [Description("Can await Coroutine")]
+        public async Task 非同期テストの例_コルーチンをawaitできる()
+        {
+            var actual = 0;
+            await FooMonoBehaviour.BarCoroutine(i =>
+            {
+                actual = i;
+            });
+
+            Assert.That(actual, Is.EqualTo(1));
+        }
+
+        // テスト対象コルーチンを含むMonoBehaviour
+        private class FooMonoBehaviour : MonoBehaviour
+        {
+            public static IEnumerator BarCoroutine(Action<int> onSuccess)
+            {
+                yield return null;
+                onSuccess(1);
+            }
+        }
+    }
+}

--- a/Assets/APIExamples/Tests/Runtime/NUnit/AsyncTestsExample.cs.meta
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/AsyncTestsExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7393a9bcfcc9423bbad4d8efed8a616b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add examples for async tests.

In Unity Test Framework v1.3,

> Async test support with documentation and support for SetUp and TearDown .

refs https://docs.unity3d.com/Packages/com.unity.test-framework@1.3/manual/reference-async-tests.html