### PR TITLE
Upgrade packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,9 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           unityVersion: ${{ matrix.unityVersion }}  # 通常は未指定（`auto`）でok
-          artifactsPath: Logs
           customParameters: -testCategory "!IgnoreCI"
-          coverageOptions: generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+<user>,+EmbeddedPackageSample*,+LocalPackageSample*,-*.Tests
-          # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.1/manual/CoverageBatchmode.html
+          coverageOptions: generateAdditionalMetrics;generateTestReferences;generateHtmlReport;generateAdditionalReports;assemblyFilters:+<assets>,+EmbeddedPackageSample*,+LocalPackageSample*,-*Tests
+          # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
         env:
           UNITY_LICENSE: ${{ secrets[steps.license.outputs.secret_key] }}
         id: test
@@ -73,7 +72,7 @@ jobs:
         with:
           name: TestResults-Unity${{ matrix.unityVersion }}
           path: |
-            Logs
+            ${{ steps.test.outputs.artifactsPath }}
             ${{ steps.test.outputs.coveragePath }}
         if: always()
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 # Code Coverage report filter (comma separated)
 # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.1/manual/CoverageBatchmode.html
-COVERAGE_ASSEMBLY_FILTERS?=+<user>,+EmbeddedPackageSample*,+LocalPackageSample*,-*.Tests
+COVERAGE_ASSEMBLY_FILTERS?=+<assets>,+EmbeddedPackageSample*,+LocalPackageSample*,-*Tests
 
 define test_arguments
   -projectPath $(PROJECT_HOME) \
@@ -64,7 +64,7 @@ define cover
     -debugCodeOptimization \
     -enableCodeCoverage \
     -coverageResultsPath $(LOG_DIR) \
-    -coverageOptions 'generateAdditionalMetrics;assemblyFilters:$(COVERAGE_ASSEMBLY_FILTERS)'
+    -coverageOptions 'generateAdditionalMetrics;generateTestReferences;dontClear;assemblyFilters:$(COVERAGE_ASSEMBLY_FILTERS)'
 endef
 
 define cover_report
@@ -75,7 +75,7 @@ define cover_report
     -quit \
     -enableCodeCoverage \
     -coverageResultsPath $(LOG_DIR) \
-    -coverageOptions 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+<project>'
+    -coverageOptions 'generateHtmlReport;generateAdditionalMetrics;generateAdditionalReports;assemblyFilters:$(COVERAGE_ASSEMBLY_FILTERS)'
 endef
 
 .PHONY: usage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Koji Hasegawa.
+# Copyright (c) 2021-2022 Koji Hasegawa.
 # This software is released under the MIT License.
 
 PROJECT_HOME?=$(PWD)
@@ -30,7 +30,7 @@ endif
 endif
 
 # Code Coverage report filter (comma separated)
-# see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.1/manual/CoverageBatchmode.html
+# see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
 COVERAGE_ASSEMBLY_FILTERS?=+<assets>,+EmbeddedPackageSample*,+LocalPackageSample*,-*Tests
 
 define test_arguments

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,7 +8,7 @@
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.3.1",
-    "com.unity.testtools.codecoverage": "1.1.1",
+    "com.unity.testtools.codecoverage": "1.2.2",
     "com.unity.textmeshpro": "2.1.6",
     "com.unity.timeline": "1.2.18",
     "com.unity.ugui": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.cysharp.unitask": "2.3.1",
+    "com.cysharp.unitask": "2.3.3",
     "com.nowsprinting.create-script-folders-with-tests": "1.1.0",
     "com.nowsprinting.local-package-sample": "file:../LocalPackages/com.nowsprinting.local-package-sample",
     "com.unity.collab-proxy": "1.14.18",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.ide.rider": "3.0.16",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.test-framework": "1.3.0",
+    "com.unity.test-framework": "1.3.1",
     "com.unity.testtools.codecoverage": "1.1.1",
     "com.unity.textmeshpro": "2.1.6",
     "com.unity.timeline": "1.2.18",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.nowsprinting.create-script-folders-with-tests": "1.1.0",
     "com.nowsprinting.local-package-sample": "file:../LocalPackages/com.nowsprinting.local-package-sample",
     "com.unity.collab-proxy": "1.14.18",
-    "com.unity.ide.rider": "3.0.15",
+    "com.unity.ide.rider": "3.0.16",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.3.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -41,7 +41,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.15",
+      "version": "3.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.cysharp.unitask": {
-      "version": "2.3.1",
+      "version": "2.3.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -73,7 +73,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -84,7 +84,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.1.1",
+      "version": "1.2.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
- Upgrade UniTask v2.3.1 to v2.3.3
- Upgrade com.unity.ide.rider v3.0.15 to v3.0.16
- Upgrade test-framework v1.3.0 to v1.3.1
- Upgrade testtools.codecoverage v1.1.1 to v1.2.2

And migrate code coverage arguments.
see https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/upgrade-guide.html