### PR TITLE
Upgrade net.tnrd.nsubstitute package v4.2.2 to v4.4.0

### DIFF
--- a/Assets/TestDoubleExample/Tests/Runtime.UsingNSubstitute/TestDoubleExample.UsingNSubstitute.Tests.asmdef
+++ b/Assets/TestDoubleExample/Tests/Runtime.UsingNSubstitute/TestDoubleExample.UsingNSubstitute.Tests.asmdef
@@ -12,9 +12,7 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "NSubstitute.dll",
-        "Castle.Core.dll",
-        "System.Threading.Tasks.Extensions.dll"
+        "NSubstitute.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,7 +12,7 @@
     "com.unity.textmeshpro": "2.1.6",
     "com.unity.timeline": "1.2.18",
     "com.unity.ugui": "1.0.0",
-    "net.tnrd.nsubstitute": "4.2.2",
+    "net.tnrd.nsubstitute": "4.4.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -124,7 +124,7 @@
       }
     },
     "net.tnrd.nsubstitute": {
-      "version": "4.2.2",
+      "version": "4.4.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
An error occurred when this upgrade package:
```
error CS0246: The type or namespace name 'NSubstitute' could not be found (are you missing a using directive or an assembly reference?)
```

Reason:
DLL wrapped assembly type changed from Runtime(any) to Editor.
Tests that are causing problems is Play mode tests.