### PR TITLE
Add examples for test-framework v1.4

### DIFF
--- a/Assets/APIExamples/Tests/Runtime/NUnit/ConstraintExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/ConstraintExample.cs
@@ -800,7 +800,7 @@ namespace APIExamples.NUnit
                 //  But was:  <System.NullReferenceException: Object reference not set to an instance of an object.
             }
 
-            [Ignore("Throws制約をasyncメソッドに使用するとUnityエディターがフリーズ（Unity Test Framework v1.3.9時点）")]
+            [Ignore("Throws制約をasyncメソッドに使用するとUnityエディターがフリーズ（Unity Test Framework v1.4.0時点）")]
             [Test]
             public async Task 非同期メソッドの例外捕捉を制約モデルで行なうことはできない_Unityエディターがフリーズ()
             {
@@ -816,7 +816,7 @@ namespace APIExamples.NUnit
                 //  See: https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-28107
             }
 
-            [Ignore("ThrowsAsyncをasyncメソッドに使用するとUnityエディターがフリーズ（Unity Test Framework v1.3.9時点）")]
+            [Ignore("ThrowsAsyncをasyncメソッドに使用するとUnityエディターがフリーズ（Unity Test Framework v1.4.0時点）")]
             [Test]
             public async Task 非同期メソッドの例外捕捉をクラシックモデルで行なうことはできない_Unityエディターがフリーズ()
             {
@@ -960,7 +960,7 @@ namespace APIExamples.NUnit
             }
 
             [Test]
-            [Explicit("Asyncテストでも期待通り動作しないので除外（Unity Test Framework v1.3.9時点）")]
+            [Explicit("Asyncテストでも期待通り動作しないので除外（Unity Test Framework v1.4.0時点）")]
             // https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-30529
             public async Task DelayedConstraint_AsyncTestでも無効()
             {

--- a/Assets/APIExamples/Tests/Runtime/NUnit/MaxTimeAttributeExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/MaxTimeAttributeExample.cs
@@ -51,7 +51,7 @@ namespace APIExamples.NUnit
             }
         }
 
-        [Explicit("MaxTime属性はUnityTest属性のテストに使用できない（Unity Test Framework v1.3.9時点）")]
+        [Explicit("MaxTime属性はUnityTest属性のテストに使用できない（Unity Test Framework v1.4.0時点）")]
         [UnityTest]
         [MaxTime(2000)]
         public IEnumerator MaxTime属性はUnityTest属性のテストに使用できない_実行時エラー()
@@ -65,7 +65,7 @@ namespace APIExamples.NUnit
             yield return new WaitForSeconds(waitSeconds);
         }
 
-        [Ignore("MaxTime属性はasyncテストに使用できない（Unity Test Framework v1.3.9時点）")]
+        [Ignore("MaxTime属性はasyncテストに使用できない（Unity Test Framework v1.4.0時点）")]
         // See: https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-28107
         [Test]
         [MaxTime(2000)]

--- a/Assets/APIExamples/Tests/Runtime/NUnit/RepeatAttributeExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/RepeatAttributeExample.cs
@@ -40,7 +40,7 @@ namespace APIExamples.NUnit
             Assert.That(true);
         }
 
-        [Ignore("Repeat属性はasyncテストに使用できない（Unity Test Framework v1.3.9時点）")]
+        [Ignore("Repeat属性はasyncテストに使用できない（Unity Test Framework v1.4.0時点）")]
         // See: https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-28107
         // Note: Unity Test Framework v1.3.5 で追加された `-repeat` コマンドラインオプションは、asyncテストにも有効です
         [Test]

--- a/Assets/APIExamples/Tests/Runtime/NUnit/RetryAttributeExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/RetryAttributeExample.cs
@@ -43,7 +43,7 @@ namespace APIExamples.NUnit
             Assert.That(_unityTestCount, Is.EqualTo(2));
         }
 
-        [Ignore("Retry属性はasyncテストに使用できない（Unity Test Framework v1.3.9時点）")]
+        [Ignore("Retry属性はasyncテストに使用できない（Unity Test Framework v1.4.0時点）")]
         // See: https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-28107
         // Note: Unity Test Framework v1.3.5 で追加された `-retry` コマンドラインオプションは、asyncテストにも有効です
         [Test]

--- a/Assets/APIExamples/Tests/Runtime/NUnit/ValueSourceAttributeExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/ValueSourceAttributeExample.cs
@@ -81,5 +81,18 @@ namespace APIExamples.NUnit
 
             Assert.That(actual, Is.EqualTo(0.5f));
         }
+
+        [Test]
+        [Description("Can skip specified combination with ParametrizedIgnoreAttribute (Required UTF v1.4+)")]
+        [ParametrizedIgnore(Element.Fire, Element.Metal)]
+        [ParametrizedIgnore(Element.Water, Element.Earth)]
+        public void GetDamageMultiplier_ParametrizedIgnore属性で指定した組み合わせはskipされる(
+            [ValueSource(nameof(s_defence1X))] Element def,
+            [ValueSource(nameof(s_attack1X))] Element atk)
+        {
+            var actual = def.GetDamageMultiplier(atk);
+
+            Assert.That(actual, Is.EqualTo(1.0f));
+        }
     }
 }

--- a/Assets/APIExamples/Tests/Runtime/NUnit/ValuesAttributeExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/ValuesAttributeExample.cs
@@ -79,5 +79,20 @@ namespace APIExamples.NUnit
 
             Assert.That(actual, Is.EqualTo(0.5f));
         }
+
+        [Test]
+        [Description("Can skip specified combination with ParametrizedIgnoreAttribute (Required UTF v1.4+)")]
+        [ParametrizedIgnore(Element.Fire, Element.Metal)]
+        [ParametrizedIgnore(Element.Water, Element.Earth)]
+        public void GetDamageMultiplier_ParametrizedIgnore属性で指定した組み合わせはskipされる(
+            [Values(Element.Wood, Element.Fire, Element.Water)]
+            Element def,
+            [Values(Element.None, Element.Earth, Element.Metal)]
+            Element atk)
+        {
+            var actual = def.GetDamageMultiplier(atk);
+
+            Assert.That(actual, Is.EqualTo(1.0f));
+        }
     }
 }

--- a/Assets/APIExamples/Tests/Runtime/UnityTestFramework/AllocatingGcMemoryExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/UnityTestFramework/AllocatingGcMemoryExample.cs
@@ -74,7 +74,7 @@ namespace APIExamples.UnityTestFramework
             Assert.That(UseColor, Is.Not.AllocatingGCMemory());
         }
 
-        [Ignore("Is.Not.AllocatingGCMemory()をasyncメソッドに使用するとUnityエディターがフリーズ（Unity Test Framework v1.3.9時点）")]
+        [Ignore("Is.Not.AllocatingGCMemory()をasyncメソッドに使用するとUnityエディターがフリーズ（Unity Test Framework v1.4.0時点）")]
         [Test]
         public async Task プリミティブ型_ヒープアロケーションなしAsync_Unityエディターがフリーズ()
         {
@@ -91,7 +91,7 @@ namespace APIExamples.UnityTestFramework
             Assert.That(async () => await UsePrimitives(), Is.Not.AllocatingGCMemory());
         }
 
-        [Explicit("Is.AllocatingGCMemory()をasyncメソッドに使用しても常に成功してしまう（Unity Test Framework v1.3.9時点）")]
+        [Explicit("Is.AllocatingGCMemory()をasyncメソッドに使用しても常に成功してしまう（Unity Test Framework v1.4.0時点）")]
         [Test]
         public async Task String型_ヒープアロケーションありAsync_常に成功してしまう()
         {

--- a/Assets/APIExamples/Tests/Runtime/UnityTestFramework/LogAssertExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/UnityTestFramework/LogAssertExample.cs
@@ -14,9 +14,10 @@ using UnityEngine.TestTools;
 namespace APIExamples.UnityTestFramework
 {
     /// <summary>
-    /// <see cref="UnityEngine.TestTools.LogAssert"/>の使用例
+    /// <see cref="UnityEngine.TestTools.LogAssert"/>の使用例.
     /// 通常、テスト実行時に<see cref="UnityEngine.Debug.Log(object)"/>および<see cref="UnityEngine.Debug.LogWarning(object)"/>
     /// 以外のメッセージが出力されるとテストは失敗しますが、その条件をコントロールできます。
+    /// <c>LogType</c>を省略できるオーバーロードは Unity Test Framework v1.4 で追加されました。
     /// </summary>
     public class LogAssertExample
     {
@@ -149,6 +150,50 @@ namespace APIExamples.UnityTestFramework
             var expectFrame = Time.frameCount;
             yield return new WaitWhile(() => expectFrame == Time.frameCount);
             LogAssert.Expect(LogType.Log, "expected message");
+        }
+
+        [Test]
+        public void ExpectWithoutLogType_期待するログメッセージが出力されること()
+        {
+            if (!Fail)
+            {
+                Debug.LogWarning("expected message");
+            }
+
+            LogAssert.Expect("expected message");
+        }
+
+        [Test]
+        public void ExpectWithoutLogType_期待する警告メッセージが出力されること()
+        {
+            if (!Fail)
+            {
+                Debug.Log("expected message");
+            }
+
+            LogAssert.Expect("expected message");
+        }
+
+        [Test]
+        public void ExpectWithoutLogType_期待するエラーログが出力されること_期待するメッセージであればLogErrorでもテストは失敗しない()
+        {
+            Debug.LogError("expected message"); // 通常、LogError出力があるとテストは失敗する
+
+            if (!Fail)
+            {
+                LogAssert.Expect("expected message");
+            }
+        }
+
+        [Test]
+        public void ExpectWithoutLogType_正規表現でマッチング可能()
+        {
+            Debug.LogError("expected message"); // 通常、LogError出力があるとテストは失敗する
+
+            if (!Fail)
+            {
+                LogAssert.Expect(new Regex("ex.+? (message|msg)"));
+            }
         }
 
         [Test]

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,7 +12,7 @@
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.7.0",
-    "com.unity.test-framework": "1.3.9",
+    "com.unity.test-framework": "1.4.0",
     "com.unity.testframework.graphics": "7.17.0-exp.1",
     "com.unity.testtools.codecoverage": "1.2.4",
     "com.unity.textmeshpro": "2.1.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -161,7 +161,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.3.9",
+      "version": "1.4.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
- Upgrade test-framework to v1.4.0
- Update limitations in test-framework v1.4.0
- Add LogAssert without LogType examples
- Add ParametrizedIgnoreAttribute examples