### PR TITLE
Fix assert destroyed object

### DIFF
--- a/Assets/APIExamples/Tests/Runtime/NUnit/ConstraintExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/ConstraintExample.cs
@@ -935,15 +935,33 @@ namespace APIExamples.NUnit
         public class 破棄されたGameObject
         {
             [Test]
-            [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
-            // Note: プレイヤーではnull判定されるため除外
             public void Boolキャストオペレーターで破棄されたGameObjectを検証する例()
             {
-                var cube = new GameObject("Cube");
-                GameObject.DestroyImmediate(cube);
+                var go = new GameObject();
+                GameObject.DestroyImmediate(go);
 
-                Assume.That(cube, Is.Not.Null); // Note: 破棄されていても参照はnullではない
-                Assert.That((bool)cube, Is.False); // Note: GameObjectが破棄されているとき、boolキャストオペレーターはfalseを返す
+                Assert.That((bool)go, Is.False); // Note: GameObjectが破棄されているとき、boolキャストオペレーターはfalseを返す
+            }
+
+            [Test]
+            [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+            public void IsNullで破棄されたGameObjectを検証する例_EditorではNotNull()
+            {
+                var go = new GameObject();
+                GameObject.DestroyImmediate(go);
+
+                Assume.That(go, Is.Not.Null); // Note: Editorでは破棄されていても参照はnullではない
+            }
+
+            [Test]
+            [UnityPlatform(exclude =
+                new[] { RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor })]
+            public void IsNullで破棄されたGameObjectを検証する例_PlayerではNull()
+            {
+                var go = new GameObject();
+                GameObject.DestroyImmediate(go);
+
+                Assume.That(go, Is.Null); // Note: Playerでは破棄されたObjectの参照はnull
             }
         }
 

--- a/Assets/APIExamples/Tests/Runtime/NUnit/CustomConstraintExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/CustomConstraintExample.cs
@@ -36,7 +36,7 @@ namespace APIExamples.NUnit
 
         [Test]
         [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
-        // Note: プレイヤーではnull判定されるため除外
+        // Note: Playerでは破棄されたObjectの参照はnull判定されるため除外
         public void CustomConstraint_Extensionsの実装も行なうと可能な書きかた()
         {
             var actual = CreateDestroyedObject();


### PR DESCRIPTION
> In the Editor, Unity overrides null checks for destroyed GameObjects to provide additional debugging visibility, meaning a destroyed GameObject reference is not null but will evaluate to false when cast to a bool. This is specific to the Editor's debugging environment.
>
> In the Player, Unity optimizes GameObject management for performance and does not retain references to destroyed GameObjects in the same way. Once destroyed, the GameObject behaves like a standard object and becomes null.

https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-94884
