### PR TITLE
Upgrade Unity versions used to run tests on CI (Unity 6.5/ test-framework v1.7.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           - 6000.0.59f2 # pin test-framework v1.6.0
           - 6000.0.78f1
           - 6000.3.18f1
-          - &latest_unity_version 6000.5.1f1
+          - &latest_unity_version 6000.5.1f1    # pin test-framework v1.7.0
         testMode:
           - All                                 # run tests in editor
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,9 @@ jobs:
           - 6000.0.43f1 # Latest version that does not pin the test framework package.
           - 6000.0.44f1 # pin test-framework v1.5.1
           - 6000.0.59f2 # pin test-framework v1.6.0
-          - 6000.3.12f1
-          - &latest_unity_version 6000.4.1f1
+          - 6000.0.78f1
+          - 6000.3.18f1
+          - &latest_unity_version 6000.5.1f1
         testMode:
           - All                                 # run tests in editor
         include:

--- a/Assets/APIExamples/Tests/Editor/UnityTestFramework/UnityTestFrameworkVersionCheck.cs
+++ b/Assets/APIExamples/Tests/Editor/UnityTestFramework/UnityTestFrameworkVersionCheck.cs
@@ -61,11 +61,19 @@ namespace APIExamples.Editor.UnityTestFramework
         }
 
         [Test]
-        [UnityVersion(newerThanOrEqual: "6000.2.6f1")]
-        public async Task Unity6000_2_6f1以降_TestFrameworkはv1_6_0固定()
+        [UnityVersion(newerThanOrEqual: "6000.2.6f1", olderThan: "6000.5.0f1")]
+        public async Task Unity6000_2_6f1から6000_5_0f1まで_TestFrameworkはv1_6_0固定()
         {
             var actual = await GetTestFrameworkPackageVersionAsync();
             Assert.That(actual, Is.EqualTo("1.6.0"));
+        }
+
+        [Test]
+        [UnityVersion(newerThanOrEqual: "6000.5.0f1")]
+        public async Task Unity6000_5_0f1以降_TestFrameworkはv1_7_0固定()
+        {
+            var actual = await GetTestFrameworkPackageVersionAsync();
+            Assert.That(actual, Is.EqualTo("1.7.0"));
         }
     }
 }

--- a/Assets/APIExamples/Tests/Runtime/APIExamples.Tests.asmdef
+++ b/Assets/APIExamples/Tests/Runtime/APIExamples.Tests.asmdef
@@ -30,6 +30,11 @@
             "name": "com.unity.test-framework",
             "expression": "1.6",
             "define": "ENABLE_UTF_1_6"
+        },
+        {
+            "name": "com.unity.test-framework",
+            "expression": "1.7",
+            "define": "ENABLE_UTF_1_7"
         }
     ],
     "noEngineReferences": false

--- a/Assets/APIExamples/Tests/Runtime/NUnit/ConstraintExample.cs
+++ b/Assets/APIExamples/Tests/Runtime/NUnit/ConstraintExample.cs
@@ -900,6 +900,9 @@ namespace APIExamples.NUnit
         [TestFixture]
         public class シリアル化
         {
+#if !ENABLE_UTF_1_7
+            // com.unity.ext.nunit 2.1.0（Unity 6.5, test-framework v1.7.0）から BinarySerializableConstraint が削除されたため除外。
+            // これは BinaryFormatter が .NET で非推奨になったための措置で、ext.nunit が NUnit 4ベースになったわけではない。
             [Serializable]
             private class BinarySerializableSample
             {
@@ -917,6 +920,7 @@ namespace APIExamples.NUnit
                 //  Expected: binary serializable
                 //  But was:  <APIExamples.NUnit.ConstraintExample+シリアル化+BinarySerializableSample>
             }
+#endif
 
             // ReSharper disable once MemberCanBePrivate.Global
             public class XmlSerializableSample

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.cysharp.unitask": "2.5.10",
-    "com.nowsprinting.create-script-folders-with-tests": "1.3.0",
+    "com.nowsprinting.create-script-folders-with-tests": "1.4.0",
     "com.nowsprinting.local-package-sample": "file:../LocalPackages/com.nowsprinting.local-package-sample",
     "com.nowsprinting.test-helper": "1.5.0",
     "com.nowsprinting.test-helper.input": "1.0.1",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.nowsprinting.test-helper": "1.3.2",
     "com.nowsprinting.test-helper.input": "1.0.1",
     "com.nowsprinting.test-helper.random": "1.1.0",
-    "com.nowsprinting.test-helper.ui": "1.1.3",
+    "com.nowsprinting.test-helper.ui": "1.3.0",
     "com.unity.ai.navigation": "2.0.6",
     "com.unity.collab-proxy": "2.7.1",
     "com.unity.ide.rider": "3.0.34",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.cysharp.unitask": "2.5.10",
     "com.nowsprinting.create-script-folders-with-tests": "1.3.0",
     "com.nowsprinting.local-package-sample": "file:../LocalPackages/com.nowsprinting.local-package-sample",
-    "com.nowsprinting.test-helper": "1.3.2",
+    "com.nowsprinting.test-helper": "1.5.0",
     "com.nowsprinting.test-helper.input": "1.0.1",
     "com.nowsprinting.test-helper.random": "1.1.0",
     "com.nowsprinting.test-helper.ui": "1.3.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.cysharp.unitask": "2.5.10",
+    "com.cysharp.unitask": "2.5.11",
     "com.nowsprinting.create-script-folders-with-tests": "1.4.0",
     "com.nowsprinting.local-package-sample": "file:../LocalPackages/com.nowsprinting.local-package-sample",
     "com.nowsprinting.test-helper": "1.5.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "url": "https://package.openupm.com"
     },
     "com.nowsprinting.create-script-folders-with-tests": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -27,7 +27,7 @@
       "dependencies": {}
     },
     "com.nowsprinting.test-helper": {
-      "version": "1.3.2",
+      "version": "1.5.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.cysharp.unitask": {
-      "version": "2.5.10",
+      "version": "2.5.11",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -50,12 +50,12 @@
       "url": "https://package.openupm.com"
     },
     "com.nowsprinting.test-helper.ui": {
-      "version": "1.1.3",
+      "version": "1.3.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.cysharp.unitask": "2.3.3",
-        "com.nowsprinting.test-helper": "1.3.1",
+        "com.nowsprinting.test-helper": "1.3.2",
         "com.nowsprinting.test-helper.random": "1.1.0",
         "com.unity.ugui": "1.0.0"
       },


### PR DESCRIPTION
## Summary

- Add Unity 6.5 (`6000.5.1f1`) to the CI test matrix
- Upgrade several packages and fix deprecated API usage introduced by Unity 6.5
- Fix compile error on Unity 6.5: guard `Is.BinarySerializable` example with `#if !ENABLE_UTF_1_7`

## Changes

### CI
- Add `6000.5.1f1` to the `unityVersion` matrix

### Package upgrades
- `com.cysharp.unitask`: 2.5.x → 2.5.11
- `com.nowsprinting.create-script-folders-with-tests`: 1.3.x → 1.4.0
- `com.nowsprinting.test-helper`: 1.4.x → 1.5.0
- `com.nowsprinting.test-helper.ui`: 1.2.x → 1.3.0

### Deprecated API fixes (Unity 6.4+, `CS0618` as error)
- Treat `CS0618` (obsolete) as a compile error (`Default.globalconfig`)
- Replace `FindObjectOfType` / `FindObjectsOfType` with `#if UNITY_2022_3_OR_NEWER` guards
- Replace `FindFirstObjectByType` with `FindAnyObjectByType` (obsolete in Unity 6.4)

### Unity 6.5 / test-framework 1.7 compatibility
- Update `UnityTestFrameworkVersionCheck` test cases to cover Unity 6.5 (`6000.5.0f1+`)
- Add `ENABLE_UTF_1_7` to `APIExamples.Tests.asmdef` `versionDefines`
- Guard `BinarySerializableConstraint` example with `#if !ENABLE_UTF_1_7`

### Misc
- Add Claude Code settings (`.claude/`)
- Bump copyright year to 2026

## Background: Why `Is.BinarySerializable` broke on Unity 6.5

Unity 6.5 ships `com.unity.test-framework` 1.7.0, which bumps `com.unity.ext.nunit`
from 2.0.5 to 2.1.0. Despite the assembly version remaining `3.5.0.0`, Unity's custom
NUnit 3.5 fork in 2.1.0 removes `BinarySerializableConstraint` — because
`BinaryFormatter` is deprecated in .NET. `XmlSerializableConstraint` is still present.

The fix adds an `ENABLE_UTF_1_7` version define (matching the repo's existing
`ENABLE_UTF_1_5` / `ENABLE_UTF_1_6` convention) and wraps the
`BinarySerializableSample` class and its test in `#if !ENABLE_UTF_1_7`.